### PR TITLE
fix: isolate successive builds

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,6 +12,10 @@ source:
   patches:
     - patches/0001-fix-fmt-mmcif-avoid-insert-function.patch
     - patches/0002-test-python-fmt-check-more-attributes.patch
+    - patches/0003-build-refactor-version-resolution.patch
+    - patches/0004-build-output-to-source-directory-only-for-stub-build.patch
+    - patches/0005-build-enable-test-only-build.patch
+    - patches/0006-build-add-doctest-only-option.patch
 
 build:
   number: 2
@@ -65,7 +69,7 @@ outputs:
           -DNURI_PREBUILT_ABSL=OFF \
           -DBUILD_TESTING=OFF"
         export CMAKE_BUILD_PARALLEL_LEVEL="${CPU_COUNT}"
-        {{ PREFIX }}/bin/python -m pip install . -vv --no-deps --no-build-isolation
+        {{ PREFIX }}/bin/python -m pip install . -vv --no-deps
 
       ignore_run_exports_from:
         # We use headers only, but need -devel instead -headers for cmake

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -53,12 +53,39 @@ outputs:
         - libabseil
         - eigen >=3.4
         - spectralib >=1.0
+      run_constrained:
+        - {{ pin_compatible("libboost-headers", max_pin="x.x") }}
 
     test:
       commands:
         - nuri
         - test -f "$PREFIX/lib/libnuri${SHLIB_EXT}"
         - test -f "$PREFIX/include/nuri/nurikit_config.h"
+        - |
+          cmake -Bbuild -S. ${CMAKE_ARGS} -GNinja \
+            -DNURI_BUILD_LIB=OFF \
+            -DNURI_BUILD_PYTHON=OFF \
+            -DNURI_PREBUILT_ABSL=OFF \
+            -DNURI_FORCE_VERSION="${PKG_VERSION}" \
+            -DBUILD_TESTING=ON
+          cmake --build build --target all -j "${CPU_COUNT}"
+
+          cd build
+          ctest -C Release -T test --output-on-failure -j "${CPU_COUNT}"
+      source_files:
+        - CMakeLists.txt
+        - cmake
+        - test
+      requires:
+        - {{ compiler('c') }}
+        - {{ stdlib('c') }}
+        - {{ compiler('cxx') }}
+        - cmake >=3.16
+        - ninja
+        - libboost-devel
+        - libabseil
+        - eigen
+        - gtest
 
   - name: nurikit
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -18,7 +18,7 @@ source:
     - patches/0006-build-add-doctest-only-option.patch
 
 build:
-  number: 2
+  number: 3
   skip: true  # [win]
 
 outputs:

--- a/recipe/patches/0003-build-refactor-version-resolution.patch
+++ b/recipe/patches/0003-build-refactor-version-resolution.patch
@@ -1,0 +1,139 @@
+From 1f7c74b50ca4ec3a203165f8e4f40490909fa5f0 Mon Sep 17 00:00:00 2001
+From: Nuri Jung <jnooree@snu.ac.kr>
+Date: Tue, 22 Apr 2025 11:30:11 +0900
+Subject: [PATCH 3/6] build: refactor version resolution
+
+---
+ cmake/NuriKitUtils.cmake | 84 +++++++++++++++++++++-------------------
+ 1 file changed, 44 insertions(+), 40 deletions(-)
+
+diff --git a/cmake/NuriKitUtils.cmake b/cmake/NuriKitUtils.cmake
+index ddd6875a..250414e3 100644
+--- a/cmake/NuriKitUtils.cmake
++++ b/cmake/NuriKitUtils.cmake
+@@ -3,10 +3,15 @@
+ # SPDX-License-Identifier: Apache-2.0
+ #
+ 
+-macro(_nuri_get_git_version_impl)
+-  find_package(Git)
++function(_nuri_get_git_version_impl)
++  set(_nuri_version_next "0.1.0.dev0")
++
++  find_package(Git QUIET)
+ 
+   if(NOT Git_FOUND)
++    message(NOTICE "Git not found! Using ${_nuri_version_next}+unknown")
++    set(NURI_FULL_VERSION "${_nuri_version_next}+unknown" PARENT_SCOPE)
++    set(NURI_REF "unknown" PARENT_SCOPE)
+     return()
+   endif()
+ 
+@@ -14,67 +19,66 @@ macro(_nuri_get_git_version_impl)
+     COMMAND ${GIT_EXECUTABLE} rev-parse --short HEAD
+     RESULT_VARIABLE git_result
+     OUTPUT_VARIABLE nuri_revision
+-    ERROR_QUIET)
++    ERROR_QUIET
++  )
+   string(STRIP "${nuri_revision}" nuri_revision)
+ 
++  if(NOT nuri_revision)
++    set(nuri_revision "unknown")
++  endif()
++
++  execute_process(
++    COMMAND ${GIT_EXECUTABLE} symbolic-ref -q --short HEAD
++    RESULT_VARIABLE git_result
++    OUTPUT_VARIABLE nuri_branch
++    ERROR_QUIET
++  )
++  string(STRIP "${nuri_branch}" nuri_branch)
++
+   execute_process(
+     COMMAND ${GIT_EXECUTABLE} describe --tags --exact-match --abbrev=0
+     RESULT_VARIABLE git_result
+-    OUTPUT_VARIABLE NURI_REF
+-    ERROR_QUIET)
++    OUTPUT_VARIABLE nuri_tag
++    ERROR_QUIET
++  )
++  string(STRIP "${nuri_tag}" nuri_tag)
+ 
+-  if(git_result EQUAL 0)
+-    string(STRIP "${NURI_REF}" NURI_REF)
++  if(nuri_tag)
++    set(NURI_REF "${nuri_tag}")
+     string(REGEX REPLACE "^v" "" NURI_FULL_VERSION "${NURI_REF}")
+     message(STATUS "NuriKit version from git: ${NURI_FULL_VERSION}")
+   else()
+-    execute_process(
+-      COMMAND ${GIT_EXECUTABLE} symbolic-ref -q --short HEAD
+-      RESULT_VARIABLE git_result
+-      OUTPUT_VARIABLE NURI_REF
+-      ERROR_QUIET)
++    set(NURI_FULL_VERSION "${_nuri_version_next}+${nuri_revision}")
++    message(NOTICE
++      "NuriKit version not found! "
++      "Assuming ${_nuri_version_next}+${nuri_revision}"
++    )
+ 
+-    if(NOT git_result EQUAL 0)
++    if(nuri_branch)
++      set(NURI_REF "${nuri_branch}")
++    else()
+       set(NURI_REF "${nuri_revision}")
+     endif()
+-
+-    string(STRIP "${NURI_REF}" NURI_REF)
+   endif()
+-endmacro()
++
++  set(NURI_FULL_VERSION "${NURI_FULL_VERSION}" PARENT_SCOPE)
++  set(NURI_REF "${NURI_REF}" PARENT_SCOPE)
++endfunction()
+ 
+ function(nuri_get_version)
+   if(SKBUILD)
+     # Version correctly set via scikit-build-core; skip git versioning.
+     set(NURI_FULL_VERSION "${SKBUILD_PROJECT_VERSION_FULL}")
++    set(NURI_REF "v${NURI_FULL_VERSION}")
+     message(
+       STATUS "NuriKit version from scikit-build-core: ${NURI_FULL_VERSION}"
+     )
+-  else()
+-    _nuri_get_git_version_impl()
+-  endif()
+-
+-  if(NURI_FORCE_VERSION)
+-    message(STATUS "Using explicit NuriKit version: ${NURI_FORCE_VERSION}")
++  elseif(NURI_FORCE_VERSION)
+     set(NURI_FULL_VERSION "${NURI_FORCE_VERSION}")
+-  endif()
+-
+-  if(NURI_REF)
+-    message(STATUS "NuriKit ref from git: ${NURI_REF}")
++    set(NURI_REF "v${NURI_FULL_VERSION}")
++    message(STATUS "Using explicit NuriKit version: ${NURI_FORCE_VERSION}")
+   else()
+-    message(NOTICE "NuriKit ref not found! Using unknown.")
+-    set(NURI_REF "unknown")
+-  endif()
+-
+-  if(nuri_revision)
+-    message(STATUS "NuriKit revision from git: ${nuri_revision}")
+-  else()
+-    message(NOTICE "NuriKit revision not found! Using unknown.")
+-    set(nuri_revision "unknown")
+-  endif()
+-
+-  if(NOT NURI_FULL_VERSION)
+-    set(NURI_FULL_VERSION "0.1.0.dev0+${nuri_revision}")
+-    message(NOTICE "NuriKit version not found! Using ${NURI_FULL_VERSION}")
++    _nuri_get_git_version_impl()
+   endif()
+ 
+   string(REGEX REPLACE "\\+.+$" "" NURI_VERSION "${NURI_FULL_VERSION}")
+-- 
+2.49.0
+

--- a/recipe/patches/0004-build-output-to-source-directory-only-for-stub-build.patch
+++ b/recipe/patches/0004-build-output-to-source-directory-only-for-stub-build.patch
@@ -1,0 +1,137 @@
+From 48393a45e8d918fe2b1b866d4b922511fe568d4f Mon Sep 17 00:00:00 2001
+From: Nuri Jung <jnooree@snu.ac.kr>
+Date: Tue, 22 Apr 2025 11:31:05 +0900
+Subject: [PATCH 4/6] build: output to source directory only for stub builds
+
+---
+ cmake/NuriKitPythonUtils.cmake | 22 +++++++++++++---------
+ python/CMakeLists.txt          | 13 -------------
+ python/src/CMakeLists.txt      | 21 +++++++++++++++++++--
+ 3 files changed, 32 insertions(+), 24 deletions(-)
+
+diff --git a/cmake/NuriKitPythonUtils.cmake b/cmake/NuriKitPythonUtils.cmake
+index 3b2a682b..fa9d87a7 100644
+--- a/cmake/NuriKitPythonUtils.cmake
++++ b/cmake/NuriKitPythonUtils.cmake
+@@ -51,9 +51,13 @@ function(nuri_python_add_module name)
+     set(subdir "")
+   endif()
+ 
+-  set(target_name "NuriPythonMod-${subdir}-${name}")
+-  string(REGEX REPLACE "/+" "-" target_name "${target_name}")
+-  string(REGEX REPLACE "-+" "-" target_name "${target_name}")
++  file(RELATIVE_PATH module
++    "${CMAKE_CURRENT_LIST_DIR}/"
++    "${CMAKE_CURRENT_LIST_DIR}/nuri/${subdir}${name}"
++  )
++  string(REGEX REPLACE "/+" "." module "${module}")
++
++  set(target_name "NuriPyMod-${module}")
+ 
+   pybind11_add_module("${target_name}" OPT_SIZE "${sources}")
+   target_link_libraries("${target_name}" PRIVATE "${PROJECT_NAME}::NuriLib")
+@@ -65,7 +69,6 @@ function(nuri_python_add_module name)
+     "${target_name}"
+     PROPERTIES
+     OUTPUT_NAME "${name}"
+-    LIBRARY_OUTPUT_DIRECTORY "${CMAKE_CURRENT_LIST_DIR}/nuri/${subdir}"
+   )
+ 
+   if(NURI_BUILD_LIB AND NURI_INSTALL_RPATH)
+@@ -81,14 +84,14 @@ function(nuri_python_add_module name)
+   endif()
+ 
+   if(NURI_BUILD_PYTHON_STUBS)
+-    file(RELATIVE_PATH submodule
+-      "${CMAKE_CURRENT_LIST_DIR}/"
+-      "${CMAKE_CURRENT_LIST_DIR}/nuri/${subdir}${name}"
++    set_target_properties(
++      "${target_name}"
++      PROPERTIES
++      LIBRARY_OUTPUT_DIRECTORY "${CMAKE_CURRENT_LIST_DIR}/nuri/${subdir}"
+     )
+-    string(REGEX REPLACE "/" "." submodule "${submodule}")
+ 
+     nuri_python_generate_stubs(
+-      "${submodule}"
++      "${module}"
+       "nuri/${subdir}${name}.pyi"
+       "${target_name}"
+       ${ARG_STUBGEN_ARGS}
+@@ -101,4 +104,5 @@ function(nuri_python_add_module name)
+   endif()
+ 
+   add_dependencies(NuriPython "${target_name}")
++  set(NURI_PYTHON_MODULE_TARGET "${target_name}" PARENT_SCOPE)
+ endfunction()
+diff --git a/python/CMakeLists.txt b/python/CMakeLists.txt
+index 6e6935ce..3f6dec1f 100644
+--- a/python/CMakeLists.txt
++++ b/python/CMakeLists.txt
+@@ -14,19 +14,6 @@ if(NURI_BUILD_PYTHON)
+     GIT_REPOSITORY https://github.com/pybind/pybind11.git
+   )
+ 
+-  configure_file(
+-    "${CMAKE_CURRENT_LIST_DIR}/src/nuri/_version.py.in"
+-    "${CMAKE_CURRENT_LIST_DIR}/src/nuri/_version.py"
+-    @ONLY
+-  )
+-
+-  if(SKBUILD)
+-    install(
+-      FILES "${CMAKE_CURRENT_LIST_DIR}/src/nuri/_version.py"
+-      DESTINATION "."
+-    )
+-  endif()
+-
+   include_directories("${CMAKE_CURRENT_LIST_DIR}/include")
+   add_compile_options(
+     -include
+diff --git a/python/src/CMakeLists.txt b/python/src/CMakeLists.txt
+index 3644e7d7..585f70bc 100644
+--- a/python/src/CMakeLists.txt
++++ b/python/src/CMakeLists.txt
+@@ -27,7 +27,9 @@ endif()
+ include(NuriKitPythonUtils)
+ 
+ nuri_python_add_module(_log_interface nuri/_log_interface_module.cpp)
+-target_link_libraries(NuriPythonMod-_log_interface PRIVATE absl::log_initialize)
++target_link_libraries("${NURI_PYTHON_MODULE_TARGET}"
++  PRIVATE absl::log_initialize
++)
+ 
+ nuri_python_add_module(_core OUTPUT_DIRECTORY "core"
+   nuri/core/_core_module.cpp
+@@ -49,12 +51,27 @@ nuri_python_add_module(fmt
+   nuri/fmt/fmt_module.cpp
+   nuri/fmt/cif.cpp
+ )
+-target_link_libraries(NuriPythonMod-fmt PRIVATE absl::span)
++target_link_libraries("${NURI_PYTHON_MODULE_TARGET}"
++  PRIVATE absl::span
++)
+ 
+ nuri_python_add_module(tm OUTPUT_DIRECTORY "tools"
+   nuri/tools/tm_module.cpp
+ )
+ 
++configure_file(
++  "${CMAKE_CURRENT_LIST_DIR}/nuri/_version.py.in"
++  "${CMAKE_CURRENT_LIST_DIR}/nuri/_version.py"
++  @ONLY
++)
++
++if(SKBUILD)
++  install(
++    FILES "${CMAKE_CURRENT_LIST_DIR}/nuri/_version.py"
++    DESTINATION "."
++  )
++endif()
++
+ if(NURI_BUILD_PYTHON_STUBS)
+   file(
+     GLOB_RECURSE NURI_PYTHON_FILES
+-- 
+2.49.0
+

--- a/recipe/patches/0005-build-enable-test-only-build.patch
+++ b/recipe/patches/0005-build-enable-test-only-build.patch
@@ -1,0 +1,165 @@
+From ecbb3ceb7a4ed23c545bfd2144ec8792f1848cb2 Mon Sep 17 00:00:00 2001
+From: Nuri Jung <jnooree@snu.ac.kr>
+Date: Tue, 22 Apr 2025 11:32:35 +0900
+Subject: [PATCH 5/6] build: enable test-only build
+
+---
+ CMakeLists.txt             | 38 ++++++++++++++++++--------------------
+ cmake/NuriKitTest.cmake    |  8 ++++++--
+ python/docs/CMakeLists.txt |  8 ++++----
+ 3 files changed, 28 insertions(+), 26 deletions(-)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index a5c6e652..cce54aaa 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -66,6 +66,8 @@ set(CMAKE_CXX_EXTENSIONS OFF)
+ set(CMAKE_CXX_STANDARD_REQUIRED ON)
+ set(CMAKE_POSITION_INDEPENDENT_CODE ON)
+ 
++set(NURI_BIBTEX_FILE "${CMAKE_CURRENT_LIST_DIR}/docs/refs.bib")
++
+ # System/compiler dependent flags
+ if(CMAKE_CXX_COMPILER_ID MATCHES Clang)
+   if(CMAKE_SYSTEM_NAME MATCHES Linux)
+@@ -145,7 +147,7 @@ if(NURI_ENABLE_SANITIZERS)
+ endif()
+ 
+ # Find/download dependencies
+-if(NURI_BUILD_LIB OR NURI_BUILD_PYTHON)
++if(NURI_BUILD_LIB OR NURI_BUILD_PYTHON OR BUILD_TESTING)
+   find_or_fetch_abseil()
+ 
+   find_or_add_package(
+@@ -177,7 +179,7 @@ spirit\\\;fusion\\\;optional\\\;container\\\;iterator\\\;range"
+     URL "https://github.com/boostorg/boost/releases/download/boost-1.87.0/boost-1.87.0-cmake.tar.xz"
+   )
+ 
+-  if(BUILD_TESTING AND NURI_BUILD_LIB)
++  if(BUILD_TESTING)
+     find_or_add_package(
+       NAME GTest
+       CPM_VERSION 1.16.0
+@@ -201,9 +203,7 @@ if(NURI_BUILD_FUZZING)
+   )
+ endif()
+ 
+-# Global project compile options / variables
+-set(NURI_BIBTEX_FILE "${CMAKE_CURRENT_LIST_DIR}/docs/refs.bib")
+-
++# Warning flags, set here to ignore warnings from dependencies
+ add_compile_options(
+   -pedantic
+   -Wall
+@@ -227,6 +227,12 @@ if(NURI_BUILD_LIB)
+   )
+   include_directories(${NURI_INCLUDE_DIRECTORIES})
+ 
++  add_subdirectory(src)
++
++  if(NURI_BUILD_DOCS)
++    add_subdirectory(docs)
++  endif()
++
+   if(NOT SKBUILD)
+     install(
+       FILES "${CMAKE_CURRENT_BINARY_DIR}/include/nuri/nurikit_config.h"
+@@ -238,11 +244,7 @@ if(NURI_BUILD_LIB)
+       DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}"
+       FILES_MATCHING PATTERN "*.h"
+     )
+-  endif()
+ 
+-  add_subdirectory(src)
+-
+-  if(NOT SKBUILD)
+     configure_package_config_file(
+       "cmake/${PROJECT_NAME}Config.cmake.in"
+       "${PROJECT_BINARY_DIR}/${PROJECT_NAME}Config.cmake"
+@@ -259,21 +261,17 @@ if(NURI_BUILD_LIB)
+       DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}"
+     )
+   endif()
++endif()
+ 
+-  if(NURI_BUILD_DOCS)
+-    add_subdirectory(docs)
+-  endif()
+-
+-  if(BUILD_TESTING)
+-    add_subdirectory(test)
+-  endif()
++if(BUILD_TESTING)
++  add_subdirectory(test)
++endif()
+ 
+-  if(NURI_BUILD_FUZZING)
+-    add_subdirectory(fuzz)
+-  endif()
++if(NURI_BUILD_FUZZING)
++  add_subdirectory(fuzz)
+ endif()
+ 
+-if(NURI_BUILD_PYTHON OR NURI_BUILD_PYTHON_DOCS)
++if(NURI_BUILD_PYTHON OR NURI_BUILD_PYTHON_DOCS OR BUILD_TESTING)
+   if(NOT SKBUILD)
+     configure_file(
+       pyproject.toml.in
+diff --git a/cmake/NuriKitTest.cmake b/cmake/NuriKitTest.cmake
+index 8e1805bd..391f477f 100644
+--- a/cmake/NuriKitTest.cmake
++++ b/cmake/NuriKitTest.cmake
+@@ -5,6 +5,10 @@
+ 
+ include(GoogleTest)
+ 
++if(NOT NURI_BUILD_LIB)
++  find_package("${PROJECT_NAME}" "${PROJECT_VERSION}" EXACT REQUIRED)
++endif()
++
+ if(NURI_ENABLE_SANITIZERS AND CMAKE_VERSION VERSION_GREATER_EQUAL 3.18)
+   set(NURI_GTEST_EXTRA_ARGS DISCOVERY_MODE PRE_TEST)
+ endif()
+@@ -27,7 +31,7 @@ function(nuri_add_test file)
+   target_link_libraries(
+     "${NURI_TEST_TARGET}"
+     PRIVATE
+-    NuriLib
++    "${PROJECT_NAME}::NuriLib"
+     GTest::gtest GTest::gmock GTest::gtest_main
+     absl::absl_log absl::absl_check
+   )
+@@ -53,7 +57,7 @@ function(nuri_add_fuzz file)
+   target_link_options("${NURI_TEST_TARGET}" PRIVATE -fsanitize=fuzzer)
+   target_link_libraries(
+     "${NURI_TEST_TARGET}"
+-    PRIVATE NuriLib absl::log_initialize
++    PRIVATE "${PROJECT_NAME}::NuriLib" absl::log_initialize
+   )
+   set_target_properties(
+     "${NURI_TEST_TARGET}"
+diff --git a/python/docs/CMakeLists.txt b/python/docs/CMakeLists.txt
+index 03b5b996..1304d3f0 100644
+--- a/python/docs/CMakeLists.txt
++++ b/python/docs/CMakeLists.txt
+@@ -34,13 +34,13 @@ if(NURI_BUILD_PYTHON_DOCS)
+     VERBATIM
+   )
+ 
+-  if(TARGET NuriPython)
+-    add_dependencies(NuriPythonDocs NuriPython)
+-  endif()
+-
+   if(TARGET NuriDocs)
+     add_dependencies(NuriPythonDocs NuriDocs)
+   endif()
++
++  if(TARGET NuriPython)
++    add_dependencies(NuriPythonDocs NuriPython)
++  endif()
+ endif()
+ 
+ if(BUILD_TESTING)
+-- 
+2.49.0
+

--- a/recipe/patches/0006-build-add-doctest-only-option.patch
+++ b/recipe/patches/0006-build-add-doctest-only-option.patch
@@ -1,0 +1,72 @@
+From e3c18fb4c7d44d452fdff30e7ab3f0cc64f677ef Mon Sep 17 00:00:00 2001
+From: Nuri Jung <jnooree@snu.ac.kr>
+Date: Tue, 22 Apr 2025 11:37:16 +0900
+Subject: [PATCH 6/6] build: add doctest-only option
+
+---
+ CMakeLists.txt             | 3 ++-
+ python/CMakeLists.txt      | 2 +-
+ python/docs/CMakeLists.txt | 6 ++----
+ 3 files changed, 5 insertions(+), 6 deletions(-)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index cce54aaa..db06ad28 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -31,6 +31,7 @@ option(NURI_BUILD_LIB "Build NuriKit library" ON)
+ option(NURI_BUILD_PYTHON "Build Python bindings" ON)
+ option(NURI_BUILD_DOCS "Build documentation" OFF)
+ option(NURI_BUILD_PYTHON_DOCS "Build python documentation" OFF)
++option(NURI_BUILD_PYTHON_DOCTEST "Build python doctest" OFF)
+ 
+ option(NURI_PREBUILT_ABSL "Download prebuilt abseil binary" ON)
+ option(NURI_INSTALL_RPATH "Install with RPATH when building full library" ON)
+@@ -271,7 +272,7 @@ if(NURI_BUILD_FUZZING)
+   add_subdirectory(fuzz)
+ endif()
+ 
+-if(NURI_BUILD_PYTHON OR NURI_BUILD_PYTHON_DOCS OR BUILD_TESTING)
++if(NURI_BUILD_PYTHON OR NURI_BUILD_PYTHON_DOCS OR NURI_BUILD_PYTHON_DOCTEST)
+   if(NOT SKBUILD)
+     configure_file(
+       pyproject.toml.in
+diff --git a/python/CMakeLists.txt b/python/CMakeLists.txt
+index 3f6dec1f..c418392e 100644
+--- a/python/CMakeLists.txt
++++ b/python/CMakeLists.txt
+@@ -23,6 +23,6 @@ if(NURI_BUILD_PYTHON)
+   add_subdirectory(src)
+ endif()
+ 
+-if(NURI_BUILD_PYTHON_DOCS OR BUILD_TESTING)
++if(NURI_BUILD_PYTHON_DOCS OR NURI_BUILD_PYTHON_DOCTEST)
+   add_subdirectory(docs)
+ endif()
+diff --git a/python/docs/CMakeLists.txt b/python/docs/CMakeLists.txt
+index 1304d3f0..fcb95f1d 100644
+--- a/python/docs/CMakeLists.txt
++++ b/python/docs/CMakeLists.txt
+@@ -11,10 +11,8 @@ find_package_handle_standard_args(Sphinx DEFAULT_MSG SPHINX_EXECUTABLE)
+ 
+ if(Sphinx_FOUND)
+   message(STATUS "Sphinx found")
+-elseif(NURI_BUILD_PYTHON_DOCS)
+-  message(FATAL_ERROR "Sphinx not found; cannot build docs")
+ else()
+-  message(NOTICE "Sphinx not found; cannot run doctest")
++  message(SEND_ERROR "Sphinx not found; cannot build docs or run doctest")
+   return()
+ endif()
+ 
+@@ -43,7 +41,7 @@ if(NURI_BUILD_PYTHON_DOCS)
+   endif()
+ endif()
+ 
+-if(BUILD_TESTING)
++if(NURI_BUILD_PYTHON_DOCTEST)
+   add_custom_target(NuriPythonDoctest
+     COMMAND ${CMAKE_COMMAND} -E env ${SANITIZER_ENVS}
+     ${SPHINX_EXECUTABLE}
+-- 
+2.49.0
+


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
